### PR TITLE
Update: Search can now receive pokemon data from fetch or session storage

### DIFF
--- a/src/Variables/globalVariables.ts
+++ b/src/Variables/globalVariables.ts
@@ -1,4 +1,4 @@
-export const POKEMON_LIMIT = 898;
+export const POKEMON_LIMIT = 45;
 export const MAX_POKEMON = 898;
 
 export const SIMPLE_KEY = "allSimplePokemon";

--- a/src/apis/fetchPokemon.ts
+++ b/src/apis/fetchPokemon.ts
@@ -1,7 +1,12 @@
 import { Pokemon } from "../types/Pokemon";
 
 export async function fetchPokemon(index: string | number) {
-  const res = await fetch(`https://pokeapi.co/api/v2/pokemon/${index}`);
-  const pokemonResult: Pokemon = await res.json();
-  return pokemonResult;
+  try {
+    const res = await fetch(`https://pokeapi.co/api/v2/pokemon/${index}`);
+    const pokemonResult: Pokemon = await res.json();
+    return pokemonResult;
+  } catch (err) {
+    return {} as Pokemon;
+  }
+
 }

--- a/src/components/CarouselWithQuery.tsx
+++ b/src/components/CarouselWithQuery.tsx
@@ -12,14 +12,6 @@ export default function CarouselWithQuery({ pokemonName }: MatchParams) {
   const [pokemon, setPokemon] = useState<Pokemon | null>(null);
   const [finishedFetching, setFinishedFetching] = useState(false);
 
-  // const getPokemon = (index: string | number) => {
-  //     const res = fetchPokemon(index);
-  //     res.then((pokemon) => {
-  //       setPokemon(pokemon);
-  //       setFinishedFetching(true);
-  //     });
-  // };
-
   useEffect(() => {
     if (pokemonName !== "") {
       const res = fetchPokemon(pokemonName);

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { Link, useLocation } from "react-router-dom";
 import getPokemonIndexFromStorage from "../utils/getPokemonIndexFromStorage";
 import "../scss/Search.scss";
@@ -9,20 +9,33 @@ export interface SearchProps {
 }
 
 export default function Search({ search, setSearch }: SearchProps) {
-  const searchIndex = getPokemonIndexFromStorage(search);
+
+  const [searchIndex, setSearchIndex] = useState(0);
+  const [isClicked, setIsClicked] = useState(false);
   const location = useLocation();
+  
+  useEffect(() => {
+    const setSearchIndexOnUseEffect = async () => {
+      setSearchIndex(await getPokemonIndexFromStorage(search));
+    };
+
+    setSearchIndexOnUseEffect();
+
+    console.log("search index result is ", searchIndex);
+  }, [search]);
+  
 
   return (
     <div>
       <Link
         to={
-          searchIndex !== ""
+          searchIndex !== 0
             ? `/pokemon/${searchIndex}`
             : `${location.pathname}`
         }
         className="link"
       >
-        <form onClick={() => setSearch("")} className="search">
+        <form onClick={() => {setSearch("")}} className="search">
           <input
             placeholder="search pokemon by name or id"
             type="text"

--- a/src/utils/getPokemonIndexFromStorage.ts
+++ b/src/utils/getPokemonIndexFromStorage.ts
@@ -1,9 +1,10 @@
 import { fetchPokemon } from "../apis/fetchPokemon";
+import PokemonGridItems from "../components/PokemonGridItems";
 import { SimplePokemon } from "../types/SimplePokemon";
 import simplifyPokemon from "./simplifyPokemon";
 
 
-export default function getPokemonIndexFromStorage(search: string | number) {
+export default async function getPokemonIndexFromStorage(search: string | number) {
     console.log("search is: ", search);
     if (search !== "") {
       const stored = sessionStorage.getItem("allSimplePokemon");
@@ -14,9 +15,15 @@ export default function getPokemonIndexFromStorage(search: string | number) {
         );
         if (filteredStoredData.length > 0) {
           return filteredStoredData[0].id;
-        } 
+        } else {
+          const pokemonData = await fetchPokemon(search);
+          if (Object.keys(pokemonData).length > 0) {
+            return pokemonData.id;
+          }
+          return 0;
+        }
       }
-      return "";
+      return 0;
     }
-    return search;
+    return 0;
   }


### PR DESCRIPTION
Make search compatible with lazy loading by enabling to search Pokemon outside of session storage. 
There is some bug that if you type Pokemon id instead of name, the last digit sometimes is omitted. maybe it is my laptop issue but might look into it later